### PR TITLE
Proxy support rewrite

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,19 +10,5 @@ ServiceTempDir = "tmp"
 
 [Services]
   [Services.default]
-    Restart = "no"
+    Restart = "yes"
     RunAsUser = ""
-
-  # Core services
-  [Services.hello]
-    Restart = "always"
-    [Services.hello.Params]
-      greeting = "env://HIHI"
-  [Services.web-assets]
-    Restart = "always"
-  [Services.login]
-    Restart = "always"
-  [Services.navigator]
-    Restart = "always"
-  [Services.service-manager]
-    Restart = "always"

--- a/docs/service-architecture.md
+++ b/docs/service-architecture.md
@@ -101,42 +101,27 @@ identity headers and injects:
 - `X-Arupa-User`
 - one `X-Arupa-Group` value per verified group
 
-An HTTP route pattern is an external mount point. By default, the matched route
-prefix is removed before dispatch to HTTP RPC, static, or proxy transports:
+HTTP RPC, static, and proxy routes preserve the matched route prefix by
+default. Routes can explicitly remove it before transport dispatch:
 
 ```yaml
 http:
   pattern: /app/
   rewrite:
+    prefix: true
     location: true
 ```
 
-For example, `/app/users?q=1` is dispatched as `/users?q=1`. HTTP RPC and proxy
-transports receive a kernel-owned `X-Forwarded-Prefix: /app` header. Query,
-Host, and request headers otherwise retain their existing behavior. The root
-pattern `/` has no mount prefix, so its path is unchanged.
+For example, `/app/users?q=1` is dispatched as `/users?q=1`. Query, Host, and
+request headers otherwise retain their existing behavior.
 
-`location` defaults to false. When enabled, it prepends the removed prefix to
-root-relative downstream `Location` response headers. Relative,
-scheme-relative, and absolute locations are unchanged. A route can explicitly
-preserve its external path:
-
-```yaml
-http:
-  pattern: /legacy/
-  rewrite:
-    prefix: false
-```
-
-`location: true` is invalid when `prefix` is explicitly false. This default
-prefix behavior applies within contract version 2 and intentionally changes
-the earlier proxy and HTTP RPC path-preservation behavior.
-
-The kernel owns these defaults: `prefix` defaults to true and `location`
-defaults to false. The internal rule represents both values as optional
-booleans. The protobuf `RewriteRule` fields are deliberately non-optional; when
-a service sends that message, both values are treated as explicit. A service
-omits the entire `rewrite` message to use the kernel defaults.
+Both `prefix` and `location` are ordinary booleans and default to false in the
+kernel. When `prefix` is enabled, HTTP RPC and proxy transports receive a
+kernel-owned `X-Forwarded-Prefix` header. When `location` is also enabled, the
+kernel prepends the removed prefix to root-relative downstream `Location`
+response headers. Relative, scheme-relative, and absolute locations are
+unchanged. `location: true` is invalid without `prefix: true`. The root pattern
+`/` has no removable mount prefix, so enabling these rules there is a no-op.
 
 ## Kernel package boundaries
 

--- a/docs/service-architecture.md
+++ b/docs/service-architecture.md
@@ -101,7 +101,36 @@ identity headers and injects:
 - `X-Arupa-User`
 - one `X-Arupa-Group` value per verified group
 
-The original path, query, and Host header are preserved.
+An HTTP route pattern is an external mount point. By default, the matched route
+prefix is removed before dispatch to HTTP RPC, static, or proxy transports:
+
+```yaml
+http:
+  pattern: /app/
+  rewrite:
+    location: true
+```
+
+For example, `/app/users?q=1` is dispatched as `/users?q=1`. HTTP RPC and proxy
+transports receive a kernel-owned `X-Forwarded-Prefix: /app` header. Query,
+Host, and request headers otherwise retain their existing behavior. The root
+pattern `/` has no mount prefix, so its path is unchanged.
+
+`location` defaults to false. When enabled, it prepends the removed prefix to
+root-relative downstream `Location` response headers. Relative,
+scheme-relative, and absolute locations are unchanged. A route can explicitly
+preserve its external path:
+
+```yaml
+http:
+  pattern: /legacy/
+  rewrite:
+    prefix: false
+```
+
+`location: true` is invalid when `prefix` is explicitly false. This default
+prefix behavior applies within contract version 2 and intentionally changes
+the earlier proxy and HTTP RPC path-preservation behavior.
 
 ## Kernel package boundaries
 

--- a/docs/service-architecture.md
+++ b/docs/service-architecture.md
@@ -132,6 +132,12 @@ http:
 prefix behavior applies within contract version 2 and intentionally changes
 the earlier proxy and HTTP RPC path-preservation behavior.
 
+The kernel owns these defaults: `prefix` defaults to true and `location`
+defaults to false. The internal rule represents both values as optional
+booleans. The protobuf `RewriteRule` fields are deliberately non-optional; when
+a service sends that message, both values are treated as explicit. A service
+omits the entire `rewrite` message to use the kernel defaults.
+
 ## Kernel package boundaries
 
 The root `internal/service` package is only the composition root and public

--- a/internal/service/adapter/grpc/adapter.go
+++ b/internal/service/adapter/grpc/adapter.go
@@ -279,9 +279,7 @@ func rewriteFromProto(in *grpcpb.RewriteRule) *spec.RewriteRule {
 	if in == nil {
 		return nil
 	}
-	prefix := in.GetPrefix()
-	location := in.GetLocation()
-	return &spec.RewriteRule{Prefix: &prefix, Location: &location}
+	return &spec.RewriteRule{Prefix: in.GetPrefix(), Location: in.GetLocation()}
 }
 
 func accessFromProto(policy *grpcpb.AccessPolicy) spec.AccessPolicy {

--- a/internal/service/adapter/grpc/adapter.go
+++ b/internal/service/adapter/grpc/adapter.go
@@ -279,12 +279,9 @@ func rewriteFromProto(in *grpcpb.RewriteRule) *spec.RewriteRule {
 	if in == nil {
 		return nil
 	}
-	var prefix *bool
-	if in.Prefix != nil {
-		value := in.GetPrefix()
-		prefix = &value
-	}
-	return &spec.RewriteRule{Prefix: prefix, Location: in.GetLocation()}
+	prefix := in.GetPrefix()
+	location := in.GetLocation()
+	return &spec.RewriteRule{Prefix: &prefix, Location: &location}
 }
 
 func accessFromProto(policy *grpcpb.AccessPolicy) spec.AccessPolicy {

--- a/internal/service/adapter/grpc/adapter.go
+++ b/internal/service/adapter/grpc/adapter.go
@@ -255,7 +255,8 @@ func routesFromProto(routes []*grpcpb.Route) ([]spec.Route, error) {
 		if httpRoute := in.GetHttp(); httpRoute != nil {
 			declaration.HTTP = &spec.HTTPRoute{
 				Method: httpRoute.GetMethod(), Pattern: httpRoute.GetPattern(),
-				Access: accessFromProto(httpRoute.GetAccess()),
+				Rewrite: rewriteFromProto(httpRoute.GetRewrite()),
+				Access:  accessFromProto(httpRoute.GetAccess()),
 			}
 		} else if socketRoute := in.GetSocketIo(); socketRoute != nil {
 			eventAccess := make(map[string]spec.AccessPolicy, len(socketRoute.GetEventAccess()))
@@ -272,6 +273,18 @@ func routesFromProto(routes []*grpcpb.Route) ([]spec.Route, error) {
 		out = append(out, declaration)
 	}
 	return out, nil
+}
+
+func rewriteFromProto(in *grpcpb.RewriteRule) *spec.RewriteRule {
+	if in == nil {
+		return nil
+	}
+	var prefix *bool
+	if in.Prefix != nil {
+		value := in.GetPrefix()
+		prefix = &value
+	}
+	return &spec.RewriteRule{Prefix: prefix, Location: in.GetLocation()}
 }
 
 func accessFromProto(policy *grpcpb.AccessPolicy) spec.AccessPolicy {

--- a/internal/service/adapter/wasm/adapter.go
+++ b/internal/service/adapter/wasm/adapter.go
@@ -266,12 +266,9 @@ func rewriteFromProto(in *wasmpb.RewriteRule) *spec.RewriteRule {
 	if in == nil {
 		return nil
 	}
-	var prefix *bool
-	if in.Prefix != nil {
-		value := in.GetPrefix()
-		prefix = &value
-	}
-	return &spec.RewriteRule{Prefix: prefix, Location: in.GetLocation()}
+	prefix := in.GetPrefix()
+	location := in.GetLocation()
+	return &spec.RewriteRule{Prefix: &prefix, Location: &location}
 }
 
 func accessFromProto(policy *wasmpb.AccessPolicy) spec.AccessPolicy {

--- a/internal/service/adapter/wasm/adapter.go
+++ b/internal/service/adapter/wasm/adapter.go
@@ -242,7 +242,8 @@ func routesFromProto(routes []*wasmpb.Route) ([]spec.Route, error) {
 		if httpRoute := in.GetHttp(); httpRoute != nil {
 			declaration.HTTP = &spec.HTTPRoute{
 				Method: httpRoute.GetMethod(), Pattern: httpRoute.GetPattern(),
-				Access: accessFromProto(httpRoute.GetAccess()),
+				Rewrite: rewriteFromProto(httpRoute.GetRewrite()),
+				Access:  accessFromProto(httpRoute.GetAccess()),
 			}
 		} else if socketRoute := in.GetSocketIo(); socketRoute != nil {
 			eventAccess := make(map[string]spec.AccessPolicy, len(socketRoute.GetEventAccess()))
@@ -259,6 +260,18 @@ func routesFromProto(routes []*wasmpb.Route) ([]spec.Route, error) {
 		out = append(out, declaration)
 	}
 	return out, nil
+}
+
+func rewriteFromProto(in *wasmpb.RewriteRule) *spec.RewriteRule {
+	if in == nil {
+		return nil
+	}
+	var prefix *bool
+	if in.Prefix != nil {
+		value := in.GetPrefix()
+		prefix = &value
+	}
+	return &spec.RewriteRule{Prefix: prefix, Location: in.GetLocation()}
 }
 
 func accessFromProto(policy *wasmpb.AccessPolicy) spec.AccessPolicy {

--- a/internal/service/adapter/wasm/adapter.go
+++ b/internal/service/adapter/wasm/adapter.go
@@ -266,9 +266,7 @@ func rewriteFromProto(in *wasmpb.RewriteRule) *spec.RewriteRule {
 	if in == nil {
 		return nil
 	}
-	prefix := in.GetPrefix()
-	location := in.GetLocation()
-	return &spec.RewriteRule{Prefix: &prefix, Location: &location}
+	return &spec.RewriteRule{Prefix: in.GetPrefix(), Location: in.GetLocation()}
 }
 
 func accessFromProto(policy *wasmpb.AccessPolicy) spec.AccessPolicy {

--- a/internal/service/httprewrite/rewrite.go
+++ b/internal/service/httprewrite/rewrite.go
@@ -1,0 +1,139 @@
+// Package httprewrite applies route-relative HTTP request and response
+// rewriting independently of the transport used to serve a route.
+package httprewrite
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"arupa/internal/service/spec"
+)
+
+const ForwardedPrefixHeader = "X-Forwarded-Prefix"
+
+type contextKey struct{}
+
+type state struct {
+	prefix   string
+	location bool
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	request     *http.Request
+	wroteHeader bool
+}
+
+// PrefixEnabled reports the effective prefix behavior. HTTP routes strip their
+// external mount prefix by default; an explicit false value preserves it.
+func PrefixEnabled(rule *spec.RewriteRule) bool {
+	return rule == nil || rule.Prefix == nil || *rule.Prefix
+}
+
+// Handler wraps next with the route's request rewrite. Matching and access
+// checks must run before this handler so they continue to use the external path.
+func Handler(pattern string, rule *spec.RewriteRule, next http.Handler) http.Handler {
+	if next == nil || !PrefixEnabled(rule) {
+		return next
+	}
+	prefix := strings.TrimSuffix(pattern, "/")
+	if prefix == "" {
+		return next
+	}
+	location := rule != nil && rule.Location
+	stripped := http.StripPrefix(prefix, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "" {
+			clone := request.Clone(request.Context())
+			clone.URL.Path = "/"
+			clone.URL.RawPath = ""
+			request = clone
+		}
+		next.ServeHTTP(w, request)
+	}))
+	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		rewrite := state{prefix: prefix, location: location}
+		ctx := context.WithValue(request.Context(), contextKey{}, rewrite)
+		stripped.ServeHTTP(w, request.WithContext(ctx))
+	})
+}
+
+// SetForwardedPrefix replaces any caller-supplied forwarding prefix with the
+// prefix established by the matched route.
+func SetForwardedPrefix(headers http.Header, request *http.Request) {
+	if headers == nil {
+		return
+	}
+	headers.Del(ForwardedPrefixHeader)
+	if rewrite, ok := fromRequest(request); ok {
+		headers.Set(ForwardedPrefixHeader, rewrite.prefix)
+	}
+}
+
+// RewriteResponseHeaders applies route-relative response rewriting in place.
+func RewriteResponseHeaders(headers http.Header, request *http.Request) {
+	rewrite, ok := fromRequest(request)
+	if !ok || !rewrite.location || headers == nil {
+		return
+	}
+	locations := headers.Values("Location")
+	if len(locations) == 0 {
+		return
+	}
+	headers.Del("Location")
+	for _, location := range locations {
+		headers.Add("Location", RewriteLocation(location, rewrite.prefix))
+	}
+}
+
+// ResponseWriter rewrites response headers when the wrapped handler commits
+// them. It is intended for non-streaming handlers such as static file serving.
+func ResponseWriter(w http.ResponseWriter, request *http.Request) http.ResponseWriter {
+	rewrite, ok := fromRequest(request)
+	if !ok || !rewrite.location {
+		return w
+	}
+	return &responseWriter{ResponseWriter: w, request: request}
+}
+
+// RewriteLocation prepends prefix to a root-relative Location. Relative,
+// scheme-relative, absolute, and invalid locations are returned unchanged.
+func RewriteLocation(location, prefix string) string {
+	if !strings.HasPrefix(location, "/") || strings.HasPrefix(location, "//") {
+		return location
+	}
+	reference, err := url.Parse(location)
+	if err != nil || reference.IsAbs() || reference.Host != "" {
+		return location
+	}
+	reference.Path = prefix + reference.Path
+	if reference.RawPath != "" {
+		reference.RawPath = (&url.URL{Path: prefix}).EscapedPath() + reference.RawPath
+	}
+	return reference.String()
+}
+
+func fromRequest(request *http.Request) (state, bool) {
+	if request == nil {
+		return state{}, false
+	}
+	rewrite, ok := request.Context().Value(contextKey{}).(state)
+	return rewrite, ok && rewrite.prefix != ""
+}
+
+func (w *responseWriter) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	RewriteResponseHeaders(w.Header(), w.request)
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *responseWriter) Write(body []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(body)
+}

--- a/internal/service/httprewrite/rewrite.go
+++ b/internal/service/httprewrite/rewrite.go
@@ -32,6 +32,12 @@ func PrefixEnabled(rule *spec.RewriteRule) bool {
 	return rule == nil || rule.Prefix == nil || *rule.Prefix
 }
 
+// LocationEnabled reports the effective Location behavior. Root-relative
+// Location headers are preserved unless explicitly enabled.
+func LocationEnabled(rule *spec.RewriteRule) bool {
+	return rule != nil && rule.Location != nil && *rule.Location
+}
+
 // Handler wraps next with the route's request rewrite. Matching and access
 // checks must run before this handler so they continue to use the external path.
 func Handler(pattern string, rule *spec.RewriteRule, next http.Handler) http.Handler {
@@ -42,7 +48,7 @@ func Handler(pattern string, rule *spec.RewriteRule, next http.Handler) http.Han
 	if prefix == "" {
 		return next
 	}
-	location := rule != nil && rule.Location
+	location := LocationEnabled(rule)
 	stripped := http.StripPrefix(prefix, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "" {
 			clone := request.Clone(request.Context())

--- a/internal/service/httprewrite/rewrite.go
+++ b/internal/service/httprewrite/rewrite.go
@@ -26,16 +26,14 @@ type responseWriter struct {
 	wroteHeader bool
 }
 
-// PrefixEnabled reports the effective prefix behavior. HTTP routes strip their
-// external mount prefix by default; an explicit false value preserves it.
+// PrefixEnabled reports whether route-prefix rewriting is enabled.
 func PrefixEnabled(rule *spec.RewriteRule) bool {
-	return rule == nil || rule.Prefix == nil || *rule.Prefix
+	return rule != nil && rule.Prefix
 }
 
-// LocationEnabled reports the effective Location behavior. Root-relative
-// Location headers are preserved unless explicitly enabled.
+// LocationEnabled reports whether root-relative Location rewriting is enabled.
 func LocationEnabled(rule *spec.RewriteRule) bool {
-	return rule != nil && rule.Location != nil && *rule.Location
+	return rule != nil && rule.Location
 }
 
 // Handler wraps next with the route's request rewrite. Matching and access

--- a/internal/service/route/registry.go
+++ b/internal/service/route/registry.go
@@ -16,6 +16,7 @@ import (
 	"arupa/internal/auth"
 	"arupa/internal/conf"
 	"arupa/internal/netx"
+	"arupa/internal/service/httprewrite"
 	"arupa/internal/service/spec"
 	"arupa/internal/service/transport"
 )
@@ -153,6 +154,18 @@ func (r *Registry) registerHTTPLocked(prepared *binding) error {
 	case spec.TransportHTTP, spec.TransportStatic, spec.TransportProxy:
 	default:
 		return r.reject(prepared.owner, prepared.route, fmt.Errorf("http route %q cannot use %s transport", prepared.route.ID, prepared.transport.Spec().Type))
+	}
+	if declaration.Rewrite != nil {
+		rewrite := *declaration.Rewrite
+		if declaration.Rewrite.Prefix != nil {
+			prefix := *declaration.Rewrite.Prefix
+			rewrite.Prefix = &prefix
+		}
+		declaration.Rewrite = &rewrite
+		if rewrite.Location && !httprewrite.PrefixEnabled(&rewrite) {
+			return r.reject(prepared.owner, prepared.route,
+				fmt.Errorf("http route %q location rewrite requires prefix rewrite", prepared.route.ID))
+		}
 	}
 	declaration.Method = normalizeMethod(declaration.Method)
 	prepared.route.HTTP = &declaration
@@ -359,23 +372,30 @@ func (r *Registry) serveBinding(current *binding, w http.ResponseWriter, request
 		return
 	}
 
-	switch current.transport.Spec().Type {
-	case spec.TransportHTTP:
-		serveRPC(current, w, request, user)
-	case spec.TransportStatic:
-		serveStatic(current, w, request)
-	case spec.TransportProxy:
-		current.transport.Handler().ServeHTTP(w, request)
-	default:
-		_ = netx.WriteError(w, http.StatusBadGateway, "invalid route transport", nil)
-	}
+	handler := httprewrite.Handler(
+		current.route.HTTP.Pattern,
+		current.route.HTTP.Rewrite,
+		http.HandlerFunc(func(w http.ResponseWriter, downstream *http.Request) {
+			switch current.transport.Spec().Type {
+			case spec.TransportHTTP:
+				serveRPC(current, w, downstream, user)
+			case spec.TransportStatic:
+				serveStatic(current, w, downstream)
+			case spec.TransportProxy:
+				current.transport.Handler().ServeHTTP(w, downstream)
+			default:
+				_ = netx.WriteError(w, http.StatusBadGateway, "invalid route transport", nil)
+			}
+		}),
+	)
+	handler.ServeHTTP(w, request)
 }
 
 func serveStatic(current *binding, w http.ResponseWriter, request *http.Request) {
+	w = httprewrite.ResponseWriter(w, request)
 	path := current.transport.StaticPath()
 	if current.transport.StaticDirectory() {
-		prefix := strings.TrimSuffix(current.route.HTTP.Pattern, "/")
-		http.StripPrefix(prefix, http.FileServer(http.Dir(path))).ServeHTTP(w, request)
+		http.FileServer(http.Dir(path)).ServeHTTP(w, request)
 		return
 	}
 	file, err := os.Open(path)
@@ -403,6 +423,7 @@ func serveRPC(current *binding, w http.ResponseWriter, request *http.Request, us
 		return
 	}
 	headers := request.Header.Clone()
+	httprewrite.SetForwardedPrefix(headers, request)
 	transport.InjectVerifiedIdentity(headers, user)
 	endpoint := current.transport.Endpoint()
 	ctx, cancel := endpoint.CallContext(request.Context())
@@ -417,7 +438,9 @@ func serveRPC(current *binding, w http.ResponseWriter, request *http.Request, us
 		_ = netx.WriteError(w, http.StatusBadGateway, "service handler failed", err)
 		return
 	}
-	for name, values := range response.Headers {
+	responseHeaders := response.Headers.Clone()
+	httprewrite.RewriteResponseHeaders(responseHeaders, request)
+	for name, values := range responseHeaders {
 		for _, value := range values {
 			w.Header().Add(name, value)
 		}

--- a/internal/service/route/registry.go
+++ b/internal/service/route/registry.go
@@ -157,16 +157,8 @@ func (r *Registry) registerHTTPLocked(prepared *binding) error {
 	}
 	if declaration.Rewrite != nil {
 		rewrite := *declaration.Rewrite
-		if declaration.Rewrite.Prefix != nil {
-			prefix := *declaration.Rewrite.Prefix
-			rewrite.Prefix = &prefix
-		}
-		if declaration.Rewrite.Location != nil {
-			location := *declaration.Rewrite.Location
-			rewrite.Location = &location
-		}
 		declaration.Rewrite = &rewrite
-		if httprewrite.LocationEnabled(&rewrite) && !httprewrite.PrefixEnabled(&rewrite) {
+		if rewrite.Location && !rewrite.Prefix {
 			return r.reject(prepared.owner, prepared.route,
 				fmt.Errorf("http route %q location rewrite requires prefix rewrite", prepared.route.ID))
 		}

--- a/internal/service/route/registry.go
+++ b/internal/service/route/registry.go
@@ -161,8 +161,12 @@ func (r *Registry) registerHTTPLocked(prepared *binding) error {
 			prefix := *declaration.Rewrite.Prefix
 			rewrite.Prefix = &prefix
 		}
+		if declaration.Rewrite.Location != nil {
+			location := *declaration.Rewrite.Location
+			rewrite.Location = &location
+		}
 		declaration.Rewrite = &rewrite
-		if rewrite.Location && !httprewrite.PrefixEnabled(&rewrite) {
+		if httprewrite.LocationEnabled(&rewrite) && !httprewrite.PrefixEnabled(&rewrite) {
 			return r.reject(prepared.owner, prepared.route,
 				fmt.Errorf("http route %q location rewrite requires prefix rewrite", prepared.route.ID))
 		}

--- a/internal/service/spec/clone.go
+++ b/internal/service/spec/clone.go
@@ -26,6 +26,10 @@ func CloneServiceRecord(record *ServiceRecord) *ServiceRecord {
 					prefix := *declaration.HTTP.Rewrite.Prefix
 					rewrite.Prefix = &prefix
 				}
+				if declaration.HTTP.Rewrite.Location != nil {
+					location := *declaration.HTTP.Rewrite.Location
+					rewrite.Location = &location
+				}
 				httpRoute.Rewrite = &rewrite
 			}
 			httpRoute.Access.Groups = append([]string(nil), declaration.HTTP.Access.Groups...)

--- a/internal/service/spec/clone.go
+++ b/internal/service/spec/clone.go
@@ -22,14 +22,6 @@ func CloneServiceRecord(record *ServiceRecord) *ServiceRecord {
 			httpRoute := *declaration.HTTP
 			if declaration.HTTP.Rewrite != nil {
 				rewrite := *declaration.HTTP.Rewrite
-				if declaration.HTTP.Rewrite.Prefix != nil {
-					prefix := *declaration.HTTP.Rewrite.Prefix
-					rewrite.Prefix = &prefix
-				}
-				if declaration.HTTP.Rewrite.Location != nil {
-					location := *declaration.HTTP.Rewrite.Location
-					rewrite.Location = &location
-				}
 				httpRoute.Rewrite = &rewrite
 			}
 			httpRoute.Access.Groups = append([]string(nil), declaration.HTTP.Access.Groups...)

--- a/internal/service/spec/clone.go
+++ b/internal/service/spec/clone.go
@@ -20,6 +20,14 @@ func CloneServiceRecord(record *ServiceRecord) *ServiceRecord {
 		out.Routes[index] = declaration
 		if declaration.HTTP != nil {
 			httpRoute := *declaration.HTTP
+			if declaration.HTTP.Rewrite != nil {
+				rewrite := *declaration.HTTP.Rewrite
+				if declaration.HTTP.Rewrite.Prefix != nil {
+					prefix := *declaration.HTTP.Rewrite.Prefix
+					rewrite.Prefix = &prefix
+				}
+				httpRoute.Rewrite = &rewrite
+			}
 			httpRoute.Access.Groups = append([]string(nil), declaration.HTTP.Access.Groups...)
 			out.Routes[index].HTTP = &httpRoute
 		}

--- a/internal/service/spec/types.go
+++ b/internal/service/spec/types.go
@@ -49,7 +49,7 @@ type Transport struct {
 
 type RewriteRule struct {
 	Prefix   *bool `json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	Location bool  `json:"location,omitempty" yaml:"location,omitempty"`
+	Location *bool `json:"location,omitempty" yaml:"location,omitempty"`
 }
 
 type HTTPRoute struct {

--- a/internal/service/spec/types.go
+++ b/internal/service/spec/types.go
@@ -47,9 +47,15 @@ type Transport struct {
 	Proxy        *ProxyTarget  `json:"proxy,omitempty" yaml:"proxy,omitempty"`
 }
 
+type RewriteRule struct {
+	Prefix   *bool `json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	Location bool  `json:"location,omitempty" yaml:"location,omitempty"`
+}
+
 type HTTPRoute struct {
 	Method  string       `json:"method,omitempty" yaml:"method,omitempty"`
 	Pattern string       `json:"pattern" yaml:"pattern"`
+	Rewrite *RewriteRule `json:"rewrite,omitempty" yaml:"rewrite,omitempty"`
 	Access  AccessPolicy `json:"access,omitempty" yaml:"access,omitempty"`
 }
 

--- a/internal/service/spec/types.go
+++ b/internal/service/spec/types.go
@@ -48,8 +48,8 @@ type Transport struct {
 }
 
 type RewriteRule struct {
-	Prefix   *bool `json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	Location *bool `json:"location,omitempty" yaml:"location,omitempty"`
+	Prefix   bool `json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	Location bool `json:"location,omitempty" yaml:"location,omitempty"`
 }
 
 type HTTPRoute struct {

--- a/internal/service/transport/registry.go
+++ b/internal/service/transport/registry.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"arupa/internal/auth"
+	"arupa/internal/service/httprewrite"
 	"arupa/internal/service/spec"
 )
 
@@ -24,6 +25,7 @@ const (
 	IdentityUserHeader          = "X-Arupa-User"
 	IdentityGroupHeader         = "X-Arupa-Group"
 	IdentityAuthenticatedHeader = "X-Arupa-Authenticated"
+	ForwardedPrefixHeader       = httprewrite.ForwardedPrefixHeader
 )
 
 type key struct {
@@ -237,7 +239,12 @@ func NewProxyHandler(target *spec.ProxyTarget, inherited map[string]string) (htt
 			request.SetURL(upstream)
 			request.Out.Host = originalHost
 			request.SetXForwarded()
+			httprewrite.SetForwardedPrefix(request.Out.Header, request.In)
 			InjectVerifiedIdentity(request.Out.Header, auth.UserFromRequest(request.In))
+		},
+		ModifyResponse: func(response *http.Response) error {
+			httprewrite.RewriteResponseHeaders(response.Header, response.Request)
+			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
 			http.Error(w, "bad gateway: "+err.Error(), http.StatusBadGateway)

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -35,6 +35,7 @@ const (
 
 type ProxyTarget = spec.ProxyTarget
 type Transport = spec.Transport
+type RewriteRule = spec.RewriteRule
 type HTTPRoute = spec.HTTPRoute
 type SocketIORoute = spec.SocketIORoute
 type Route = spec.Route

--- a/proto/panel.proto
+++ b/proto/panel.proto
@@ -112,10 +112,16 @@ message Transport {
   }
 }
 
+message RewriteRule {
+  optional bool prefix = 1;
+  bool location = 2;
+}
+
 message HTTPRoute {
   string method = 1;
   string pattern = 2;
   AccessPolicy access = 3;
+  RewriteRule rewrite = 4;
 }
 
 message SocketIORoute {

--- a/proto/panel.proto
+++ b/proto/panel.proto
@@ -113,7 +113,7 @@ message Transport {
 }
 
 message RewriteRule {
-  optional bool prefix = 1;
+  bool prefix = 1;
   bool location = 2;
 }
 


### PR DESCRIPTION
## Changes
- Support rewrite for http requests

## Breaking changes
- Static transport now no longer automatically strip prefix, need explicit `rewrite.prefix = true`
